### PR TITLE
Removed superfluous condition in execute()

### DIFF
--- a/src/PDOStatement.php
+++ b/src/PDOStatement.php
@@ -25,11 +25,7 @@ class PDOStatement extends \PDOStatement {
 	 * @return PDOStatement
 	 */
 	public function execute ($parameters = []) {
-		if ($parameters) {
-			$execute = parent::execute($parameters);
-		} else {
-			$execute = parent::execute();
-		}
+		$execute = parent::execute($parameters);
 
 		if ($execute === false) {
 			$error = $this->errorInfo();


### PR DESCRIPTION
PDO's execute() accepts both empty array or NULL all right, no need for condition.
